### PR TITLE
fix: Write integration tests for wallet rotation and cooldown logic

### DIFF
--- a/tests/test_farmer.py
+++ b/tests/test_farmer.py
@@ -1,6 +1,9 @@
 """Tests for the farming agent."""
 
 import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
 from src.agent.wallet_manager import WalletManager, Wallet
 from src.agent.farmer import FarmingAgent
 from src.strategies.bridge_strategy import BridgeStrategy
@@ -88,3 +91,117 @@ def test_eligibility_scoring():
         w.record_activity("arbitrum", "stargate", "Bridge", gas_spent=0.01)
     score = strategy.evaluate_eligibility(w)
     assert score > 0
+
+
+# Helper to count wallet activity for a specific day
+def get_wallet_daily_activity_count(wallet: Wallet, current_time: datetime) -> int:
+    today = current_time.date()
+    return sum(1 for activity in wallet.activity if activity.timestamp.date() == today)
+
+
+def test_farmer_wallet_cooldown_mechanics():
+    wm = WalletManager(simulate=True)
+    w1 = wm.create_wallet("w1")
+    w2 = wm.create_wallet("w2")
+    w3 = wm.create_wallet("w3")
+
+    initial_time = datetime(2023, 1, 1, 10, 0, 0)
+    cooldown_duration = timedelta(hours=1)
+    max_actions_per_day = 1 # Set to 1 for quick cooldown triggering
+
+    config = {
+        "simulate": True,
+        "min_delay_seconds": 0,
+        "max_delay_seconds": 0,
+        "wallet_cooldown_hours": cooldown_duration.total_seconds() / 3600, # agent config expects hours
+        "max_actions_per_day": max_actions_per_day,
+    }
+    agent = FarmingAgent(wm, config)
+    agent.add_strategy(BridgeStrategy())
+
+    # Use patch to control datetime.utcnow for time-sensitive logic
+    # This mock affects Wallet.record_activity and Wallet.is_on_cooldown
+    with patch('src.agent.wallet_manager.datetime') as mock_wm_datetime:
+        mock_wm_datetime.utcnow.return_value = initial_time
+        # Set a side_effect to ensure other datetime methods (like timedelta arithmetic) work normally
+        mock_wm_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+
+        # --- Test: Cooldown triggers after N actions (N=1 here) ---
+
+        # Tick 1: w1 performs 1 action, hits max_actions_per_day, goes on cooldown.
+        agent.run(ticks=1)
+        assert get_wallet_daily_activity_count(w1, initial_time) == 1
+        assert w1.is_on_cooldown
+        assert w1.cooldown_until == initial_time + cooldown_duration
+        assert agent.total_actions == 1
+        assert not w2.is_on_cooldown # w2 not yet acted
+        assert not w3.is_on_cooldown # w3 not yet acted
+
+        # --- Test: Cooled-down wallets are skipped ---
+
+        # Tick 2: w1 is on cooldown. `wm.get_next_wallet()` should skip w1.
+        # Next in logical rotation from available wallets is w2.
+        agent.run(ticks=1)
+        assert get_wallet_daily_activity_count(w2, initial_time) == 1
+        assert w2.is_on_cooldown
+        assert w2.cooldown_until == initial_time + cooldown_duration
+        assert agent.total_actions == 2
+        assert w1.is_on_cooldown # w1 still cooled down
+
+        # Tick 3: w1, w2 are on cooldown. w3 should be picked.
+        agent.run(ticks=1)
+        assert get_wallet_daily_activity_count(w3, initial_time) == 1
+        assert w3.is_on_cooldown
+        assert w3.cooldown_until == initial_time + cooldown_duration
+        assert agent.total_actions == 3
+        assert w1.is_on_cooldown # w1 still cooled down
+        assert w2.is_on_cooldown # w2 still cooled down
+
+        # After 3 ticks, all wallets have performed 1 action and should be on cooldown.
+        assert not wm.get_available_wallets() # No wallets should be available
+
+        # Tick 4: No wallets available. Agent should perform no actions.
+        agent.run(ticks=1)
+        assert agent.total_actions == 3 # Total actions remains 3
+
+        # --- Test: Wallets re-enter after expiry ---
+
+        # Advance time past cooldown for all wallets
+        new_time = initial_time + cooldown_duration + timedelta(minutes=1)
+        mock_wm_datetime.utcnow.return_value = new_time
+        mock_wm_datetime.now.return_value = new_time
+
+        # All wallets should now be off cooldown
+        assert not w1.is_on_cooldown
+        assert not w2.is_on_cooldown
+        assert not w3.is_on_cooldown
+        assert len(wm.get_available_wallets()) == 3 # All wallets available again
+
+        # Tick 5: w1 should be picked again.
+        # Rotation index in WalletManager correctly wraps around the newly available wallets.
+        agent.run(ticks=1)
+        # Verify new activity recorded on the new "day" (due to time jump)
+        assert get_wallet_daily_activity_count(w1, new_time) == 1
+        assert len(w1.activity) == 2 # Total activity count increased
+        assert w1.is_on_cooldown # w1 should go on cooldown again
+        assert w1.cooldown_until == new_time + cooldown_duration
+        assert agent.total_actions == 4
+
+        # Tick 6: w1 is on cooldown. Next available in rotation is w2.
+        agent.run(ticks=1)
+        assert get_wallet_daily_activity_count(w2, new_time) == 1
+        assert len(w2.activity) == 2
+        assert w2.is_on_cooldown
+        assert w2.cooldown_until == new_time + cooldown_duration
+        assert agent.total_actions == 5
+
+        # Tick 7: w1, w2 on cooldown. Next available in rotation is w3.
+        agent.run(ticks=1)
+        assert get_wallet_daily_activity_count(w3, new_time) == 1
+        assert len(w3.activity) == 2
+        assert w3.is_on_cooldown
+        assert w3.cooldown_until == new_time + cooldown_duration
+        assert agent.total_actions == 6
+
+        assert not wm.get_available_wallets() # All wallets cooled down again


### PR DESCRIPTION
Closes #7

## What changed
The issue requests integration tests for the `FarmingAgent`'s wallet rotation and cooldown logic. The existing `tests/test_farmer.py` includes basic wallet rotation tests within `WalletManager` but lacks coverage for the `FarmingAgent`'s interaction with cooldown rules (`max_actions_per_day`, `wallet_cooldown_hours`) and how it affects wallet selection. The fix involves adding a new, comprehensive

## Files modified
- `tests/test_farmer.py`

---
*Draft PR — please review before merging.*