### PR TITLE
chore: add Dependabot for pip dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Adds Dependabot to keep pip dependencies updated weekly.

## Changes

- .github/dependabot.yml — pip package ecosystem, weekly schedule

## Bounty

Claims #1613 if applicable (3 RTC)

RTC Wallet: chenzhizhuan