### PR TITLE
docs: fix inconsistent package name in README (scout → `scout-onchain`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is **not** a turnkey production farmer:
 
 For the *intelligence layer* (target registry, fit scoring, wallet activity tracking) used by the production agent, see **[kcolbchain/scout](https://github.com/kcolbchain/scout)** — it's a standalone library: `pip install scout-onchain`.
 
-The kcolbchain operational agent that actually executes transactions is private. That repo lives separately and uses scout as a dependency.
+The kcolbchain operational agent that actually executes transactions is private. That repo lives separately and uses `scout-onchain` as a dependency.
 
 ## Why publish a scaffold?
 


### PR DESCRIPTION
### What
Replace the informal `scout` reference with the correct PyPI package name `` `scout-onchain` `` in the "What this is" section of the README.

### Why
The rest of the README consistently uses `scout-onchain` (the installable package name) when referring to the dependency, but this one sentence drops the backticks and uses the informal name, which could confuse readers trying to install it.

Small, scoped fix from kcolbchain contrib-bot.