### PR TITLE
harden(ci): wire CI workflow, skip solana stub test when solders missing, add SECURITY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  pytest:
+    name: pytest (py${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # monsoon
 
+[![CI](https://github.com/kcolbchain/monsoon/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/monsoon/actions/workflows/ci.yml)
+
 > Research scaffold for autonomous airdrop farming agents — multi-wallet, multi-chain, simulation-first.
 
 By [kcolbchain](https://kcolbchain.com) (est. 2015).

--- a/tests/test_solana_connector.py
+++ b/tests/test_solana_connector.py
@@ -5,8 +5,15 @@ from unittest.mock import MagicMock, patch
 
 from src.chains.solana.connector import SolanaConnector, SolanaWallet, NETWORKS
 
+try:
+    import solders  # noqa: F401
+    HAS_SOLDERS = True
+except ImportError:
+    HAS_SOLDERS = False
+
 
 class TestSolanaWallet:
+    @pytest.mark.skipif(not HAS_SOLDERS, reason="solders not installed; connector falls back to stub")
     def test_generate_new_wallet(self):
         wallet = SolanaWallet()
         assert wallet.pubkey


### PR DESCRIPTION
## Summary

\`test_generate_new_wallet\` fails in any environment without \`solders\` on the path:

\`\`\`
AssertionError: assert 11 > 30
 +  where 11 = len('STUB_PUBKEY')
 +    where 'STUB_PUBKEY' = SolanaWallet(...).pubkey
\`\`\`

The \`SolanaConnector\` deliberately falls back to a stub wallet (\`STUB_PUBKEY\`, 11 chars) when \`solders\` isn't importable — see the \`solders not installed -- using stub wallet\` log. The test asserts \`len(pubkey) > 30\` (a real base58 pubkey), but that contract only holds when solders is actually installed. So the test fails on any CI image without the (optional, native) solders dependency.

## Fix

Detect solders at import-time and skip the test cleanly when unavailable:

\`\`\`python
try:
    import solders  # noqa: F401
    HAS_SOLDERS = True
except ImportError:
    HAS_SOLDERS = False

class TestSolanaWallet:
    @pytest.mark.skipif(not HAS_SOLDERS, reason=\"solders not installed; connector falls back to stub\")
    def test_generate_new_wallet(self):
        ...
\`\`\`

Preserves the regression intent (when solders IS present, the assertion still pins real-base58 behaviour) while making CI robust.

## Result

\`\`\`
99 passed, 1 skipped in 1.12s
\`\`\`

(was 99 passed, 1 failed)

## Drive-by

- CI workflow + badge — repo had tests but no CI.
- SECURITY.md.

## Note (out of scope)

Repo has **315 \`datetime.utcnow()\` deprecation warnings** on Python 3.14. \`utcnow()\` is gone in a future Python; recommend a coordinated \`datetime.now(timezone.utc)\` sweep (same pattern as scout PR #17). Happy to follow up in a separate PR.