### PR TITLE
docs: fix inconsistent wording for scout's wallet activity feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 By [kcolbchain](https://kcolbchain.com) (est. 2015).
 
 **Documentation:** [docs.kcolbchain.com/monsoon](https://docs.kcolbchain.com/monsoon/)
-**Powered by:** [kcolbchain/scout](https://github.com/kcolbchain/scout) for the registry, fit scoring, and wallet activity primitives.
+**Powered by:** [kcolbchain/scout](https://github.com/kcolbchain/scout) for the registry, fit scoring, and wallet activity tracking.
 
 ## What this is
 


### PR DESCRIPTION
### What
Change "wallet activity primitives" → "wallet activity tracking" in the opening tagline of README.md.

### Why
The same feature is called "wallet activity tracking" two paragraphs later, and the corresponding scout class is named `WalletTracker`. "Primitives" is the odd word out and may confuse readers about what the feature actually does.

Small, scoped fix from kcolbchain contrib-bot.