### PR TITLE
Skip Solana keypair test when solders is absent; add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        # `solders` is an optional dependency and is intentionally not
+        # installed here; the Solana keypair test skips gracefully when
+        # it is absent. Everything else must pass.
+        run: python -m pytest -q

--- a/tests/test_solana_connector.py
+++ b/tests/test_solana_connector.py
@@ -8,6 +8,10 @@ from src.chains.solana.connector import SolanaConnector, SolanaWallet, NETWORKS
 
 class TestSolanaWallet:
     def test_generate_new_wallet(self):
+        # Generating a real base58 keypair requires the optional `solders`
+        # dependency. When it's absent, SolanaWallet falls back to a stub
+        # ("STUB_PUBKEY"), so skip rather than hard-fail.
+        pytest.importorskip("solders")
         wallet = SolanaWallet()
         assert wallet.pubkey
         assert len(wallet.pubkey) > 30  # base58 pubkey


### PR DESCRIPTION
## What

Two changes:

1. **Fix a brittle test.** `tests/test_solana_connector.py::TestSolanaWallet::test_generate_new_wallet` hard-failed whenever the optional `solders` dependency was not installed. Without `solders`, `SolanaWallet()` falls back to a stub wallet with `pubkey = "STUB_PUBKEY"` (11 chars), but the test asserts `len(wallet.pubkey) > 30` (a real base58 pubkey). The test now guards with `pytest.importorskip("solders")`, so it **skips gracefully** instead of failing when the dep is absent.

2. **Add CI.** New `.github/workflows/ci.yml` runs `python -m pytest -q` on every push and PR to `main`, across Python 3.10 / 3.11 / 3.12. `solders` is intentionally *not* installed in CI, which exercises the new skip path.

## Why

`solders` is an optional dependency (the Solana connector degrades to a stub without it). A missing optional dep should not turn the whole suite red. There was also no CI, so regressions could land silently.

## Verification

With `solders` absent (the default environment), `python3 -m pytest -q`:

```
SKIPPED [1] tests/test_solana_connector.py:14: could not import 'solders': No module named 'solders'
99 passed, 1 skipped in ~1s
```

The previously-failing test now skips; the other 99 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)