### PR TITLE
fix: make SolanaStrategy compatible with FarmingAgent

### DIFF
--- a/src/strategies/solana_strategy.py
+++ b/src/strategies/solana_strategy.py
@@ -67,12 +67,13 @@ class SolanaStrategy(BaseStrategy):
         self.connector = SolanaConnector(network=network, simulate=simulate)
         self._activity_log: list[SolanaActivity] = []
 
-    def get_actions(self, wallet: SolanaWallet, **kwargs) -> list[Action]:
+    def get_actions(self, wallet: SolanaWallet, chain: str) -> list[Action]:
         """
         Generate farming actions for a Solana wallet.
 
         Args:
             wallet: SolanaWallet instance
+            chain: Chain selected by the farming agent.
 
         Returns:
             List of Action objects representing activity to perform
@@ -204,6 +205,10 @@ class SolanaStrategy(BaseStrategy):
         if self.simulate:
             return self._simulate_action(wallet, action)
         return self._live_action(wallet, action)
+
+    def execute(self, wallet: SolanaWallet, chain: str, action: Action) -> dict:
+        """Execute an action through the common strategy interface."""
+        return self.execute_action(wallet, action)
 
     def _simulate_action(self, wallet: SolanaWallet, action: Action) -> dict:
         """Simulate an action without network calls."""

--- a/tests/test_farmer.py
+++ b/tests/test_farmer.py
@@ -5,6 +5,7 @@ from src.agent.wallet_manager import WalletManager, Wallet
 from src.agent.farmer import FarmingAgent
 from src.strategies.bridge_strategy import BridgeStrategy
 from src.strategies.dex_strategy import DexStrategy
+from src.strategies.solana_strategy import SolanaStrategy
 
 
 def test_wallet_creation():
@@ -73,6 +74,21 @@ def test_farmer_runs_simulation():
     assert agent.total_actions > 0
     status = agent.get_status()
     assert status["total_actions"] > 0
+
+
+def test_farmer_runs_solana_strategy():
+    wm = WalletManager(simulate=True)
+    wallet = wm.create_wallet("solana-sim")
+    config = {"simulate": True, "min_delay_seconds": 0, "max_delay_seconds": 0,
+              "wallet_cooldown_hours": 4, "max_actions_per_day": 100}
+    agent = FarmingAgent(wm, config)
+    agent.add_strategy(SolanaStrategy(network="devnet", simulate=True))
+
+    agent.run(ticks=1)
+
+    assert agent.total_actions == 1
+    assert agent.errors == []
+    assert wallet.activity[0].chain == "solana"
 
 
 def test_eligibility_scoring():


### PR DESCRIPTION
## Summary

- implement the `BaseStrategy.execute()` contract in `SolanaStrategy`
- accept the positional `chain` argument that `FarmingAgent` passes to every strategy
- add an integration test that runs and records one simulated Solana farming tick

## Root cause

`SolanaStrategy` exposed `execute_action()` instead of the abstract `execute()` method, so Python refused to instantiate it:

```
TypeError: Can't instantiate abstract class SolanaStrategy without an implementation for abstract method 'execute'
```

After satisfying that abstract method, the agent hit a second interface mismatch because `get_actions()` did not accept the positional `chain` argument used by `FarmingAgent`.

Together, these errors meant enabling the Solana strategy in configuration failed before any action could run.

## Verification

- `python -m pytest tests/test_farmer.py::test_farmer_runs_solana_strategy -q`
- `python -m pytest -q` -> 101 passed with the existing optional `solders` dependency installed
- verified `run.setup_strategies()` creates a simulated devnet `SolanaStrategy`

Without optional `solders`, the repository's existing wallet test still fails on `STUB_PUBKEY`; that separate baseline issue is already covered by #39 and is intentionally outside this PR.
